### PR TITLE
IMPROVEMENT: Adding aws_main_route_table_association to

### DIFF
--- a/aws/Modules/Route_Tables/main.tf
+++ b/aws/Modules/Route_Tables/main.tf
@@ -23,3 +23,8 @@ resource "aws_route_table" "route_table" {
         Name = "${var.tag_name}"
     }
 }
+
+resource "aws_main_route_table_association" "main_route_table_association" {
+    vpc_id = "${data.aws_vpc.vpc_data.id}"
+    route_table_id = "${aws_route_table.route_table.id}"
+}


### PR DESCRIPTION
route tables main.tf, without it subnets created
are not used by EC2 instances upon creation